### PR TITLE
Issue #3025: Add more steps to release notes.

### DIFF
--- a/procedures/docs/create-release-bug-fix.md
+++ b/procedures/docs/create-release-bug-fix.md
@@ -9,7 +9,10 @@ Steps to create a BUG-FIX release
 - [ ] Create the next bugfix milestone (assign to quicksketch / serundeputy / jenlampton)
 - [ ] Move all unfinished issues to the next bugfix release milestone (assign to quicksketch / serundeputy / jenlampton)
 - [ ] Draft Release notes (assign to serundeputy / quicksketch / jenlampton)
+  - [ ] Short, descriptive summary of the release
   - [ ] Note if any changes were made to files outside the `core` directory
+  - [ ] Note if updates (update.php) needs to be run
+  - [ ] Include changelog since last version (generated with drush rn)
 - If this is a security release:
   - [ ] Draft Security Advisory (assign to serundeputy / quicksketch / jenlampton)
 

--- a/procedures/docs/create-release-major.md
+++ b/procedures/docs/create-release-major.md
@@ -9,7 +9,10 @@ Steps to create a MAJOR release
 - [ ] Create the next minor milestone (assign to quicksketch / serundeputy / jenlampton)
 - [ ] Move all unfinished issues to the next major release milestone (assign to quicksketch / serundeputy / jenlampton)
 - [ ] Draft Release notes (assign to serundeputy / quicksketch / jenlampton)
+  - [ ] Short, descriptive summary of the release
   - [ ] Note if any changes were made to files outside the `core` directory
+  - [ ] Note if updates (update.php) needs to be run
+  - [ ] Include changelog since last version (generated with drush rn)
 - [ ] Draft blog post (assign to tomgrandy / klonos / jenlampton / quicksketch)
 - [ ] Draft a newsletter via MailChimp (assign to facetinteractive / tomgrandy / jenlampton)
 

--- a/procedures/docs/create-release-minor.md
+++ b/procedures/docs/create-release-minor.md
@@ -7,7 +7,10 @@ DRAFT Steps to create a MINOR release
 - [ ] Merge commits (assign to quicksketch / serundeputy / docwilmot)
 - [ ] Move all unfinished issues to the next bugfix release milestone @quicksketch, @serundeputy
 - [ ] Draft Release notes (assign to serundeputy / quicksketch / jenlampton)
+  - [ ] Short, descriptive summary of the release
   - [ ] Note if any changes were made to files outside the `core` directory
+  - [ ] Note if updates (update.php) needs to be run
+  - [ ] Include changelog since last version (generated with drush rn)
 
 
 ## Release tasks


### PR DESCRIPTION
One of the recommendations from https://github.com/backdrop/backdrop-issues/issues/3025 was to explicitly state whether files outside of core were modified. This adds some additional steps to the release notes, which we do anyway but now they're documented.