### PR TITLE
Issue #4859: Use GitHub actions to generate release notes automatically.

### DIFF
--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -1,9 +1,13 @@
-# Configuration of Changelog Generator
+# Changelog Generator configuration.
 # @see https://github.com/spring-io/github-changelog-generator#customizing-sections
 
 changelog:
   sections:
   - title: New features
-    labels: [enhancement]
+    labels: [type - feature request]
   - title: Bug fixes
-    labels: [bug]
+    labels: [type - bug report]
+  - title: Documentation updates
+    labels: [type - documentation]
+  - title: Miscellaneous changes
+    labels: [type - task]

--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -1,0 +1,9 @@
+# Configuration of Changelog Generator
+# @see https://github.com/spring-io/github-changelog-generator#customizing-sections
+
+changelog:
+  sections:
+  - title: New features
+    labels: [enhancement]
+  - title: Bug fixes
+    labels: [bug]

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,14 +1,12 @@
+# Generate release notes (in the wiki) when a milestone is closed.
+# @see https://github.com/marketplace/actions/release-notes-generator
+# @see https://github.com/marketplace/actions/wiki-page-creator-action
+
 name: Release Notes Generator
 
 on:
   milestone:
     types: [closed]
-  workflow_dispatch:
-    inputs:
-      milestoneId:
-        description: Milestone ID
-        default: Test
-        required: true
 
 jobs:
   release-notes:
@@ -24,9 +22,9 @@ jobs:
     - name: Wiki page creator
       uses: docker://decathlon/wiki-page-creator-action:2.0.3
       env:
-        ACTION_MAIL: BWPanda@users.noreply.github.com
-        ACTION_NAME: BWPanda
-        GH_PAT: ${{ secrets.GH_PAT }}
+        ACTION_MAIL: 17776673+dragonbot@users.noreply.github.com
+        ACTION_NAME: dragonbot
+        GH_PAT: ${{ secrets.DRAGONBOT_GH_PAT }}
         MD_FOLDER: temp_release_notes
-        OWNER: BWPanda
+        OWNER: backdrop
         REPO_NAME: backdrop-issues

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,29 @@
+name: Release Notes Generator
+
+on:
+  workflow_dispatch:
+    inputs:
+      milestoneId:
+        description: Milestone ID
+        default: Test
+        required: true
+
+jobs:
+  release-notes:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Release notes generator
+      uses: Decathlon/release-notes-generator-action@v3.1.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        OUTPUT_FOLDER: temp_release_notes
+        USE_MILESTONE_TITLE: true
+    - name: Wiki page creator
+      uses: Decathlon/wiki-page-creator-action@v2.0.0
+      env:
+        ACTION_MAIL: BWPanda@users.noreply.github.com
+        ACTION_NAME: BWPanda
+        GH_PAT: ${{ secrets.GH_PAT }}
+        MD_FOLDER: temp_release_notes
+        OWNER: BWPanda
+        REPO_NAME: backdrop-issues

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,6 +1,8 @@
 name: Release Notes Generator
 
 on:
+  milestone:
+    types: [closed]
   workflow_dispatch:
     inputs:
       milestoneId:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -12,14 +12,15 @@ jobs:
   release-notes:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - name: Release notes generator
-      uses: Decathlon/release-notes-generator-action@v3.1.0
+      uses: docker://decathlon/release-notes-generator-action:3.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         OUTPUT_FOLDER: temp_release_notes
         USE_MILESTONE_TITLE: true
     - name: Wiki page creator
-      uses: Decathlon/wiki-page-creator-action@v2.0.0
+      uses: docker://decathlon/wiki-page-creator-action:2.0.3
       env:
         ACTION_MAIL: BWPanda@users.noreply.github.com
         ACTION_NAME: BWPanda


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4859